### PR TITLE
don't strech <img>'s, ensure original size

### DIFF
--- a/layouts/boilerplate.html
+++ b/layouts/boilerplate.html
@@ -24,7 +24,7 @@
 
       @import url('https://fonts.googleapis.com/css?family=Merriweather|Open+Sans');
 
-      img {border: 0; line-height: 100%; vertical-align: middle;}
+      img { width: 100%; height: 100%; object-fit: contain; border: 0; line-height: 100%; vertical-align: middle;}
       .col {font-size: 16px; line-height: 25px; vertical-align: top;}
 
       @media screen {


### PR DESCRIPTION
Thanks for a great and minimal email template. 

I've been running with it in my project briefcake.com and had multiple complaints about stretched images.
![Screenshot from 2022-05-21 13-04-22](https://user-images.githubusercontent.com/544377/169648833-0849f684-5de5-41cb-9d07-844d7e29ef8d.png)
![photo_2022-05-21_13-05-20](https://user-images.githubusercontent.com/544377/169648875-d7d3d01a-ab03-4b71-ab82-74e095fbccc2.jpg)
![photo_2022-05-21_13-05-14](https://user-images.githubusercontent.com/544377/169648876-e54ebbd4-9286-40ee-b1dd-a86fd7e95e5d.jpg)
![photo_2022-05-21_13-05-10](https://user-images.githubusercontent.com/544377/169648879-3eec2541-fe81-42d2-bfe3-c7d36d92ddf7.jpg)


These CSS rules ensure that images will be of original size. I thought, that this will useful improvement in origina template - so decided to upstream these changes.